### PR TITLE
Fixes for recent boosts (1.65, 1.68).

### DIFF
--- a/include/libport/cassert
+++ b/include/libport/cassert
@@ -106,7 +106,7 @@ namespace libport
 }
 
 #  define enforce(Exp, ...)                                             \
-  libport::enforce_(__FILE__, __LINE__ , likely(Exp), #Exp, ##__VA_ARGS__)
+  libport::enforce_(__FILE__, __LINE__ , libport_likely(Exp), #Exp, ##__VA_ARGS__)
 
 
 /*-------------------------------------------------------------------.

--- a/include/libport/compiler.hh
+++ b/include/libport/compiler.hh
@@ -229,11 +229,11 @@
 // }
 
 # if GCC_VERSION_GE(4, 3)
-#  define likely(Exp)   __builtin_expect(!!(Exp), 1)
-#  define unlikely(Exp) __builtin_expect(!!(Exp), 0)
+#  define libport_likely(Exp)   __builtin_expect(!!(Exp), 1)
+#  define libport_unlikely(Exp) __builtin_expect(!!(Exp), 0)
 # else
-#  define likely(Exp)   (Exp)
-#  define unlikely(Exp) (Exp)
+#  define libport_likely(Exp)   (Exp)
+#  define libport_unlikely(Exp) (Exp)
 # endif
 
 

--- a/include/libport/destructible.hxx
+++ b/include/libport/destructible.hxx
@@ -9,7 +9,7 @@
  */
 
 #ifndef LIBPORT_DESTRUCTIBLE_HXX
-# define LIBORT_DESTRUCTIBLE_HXX
+# define LIBPORT_DESTRUCTIBLE_HXX
 
 # include <libport/debug.hh>
 

--- a/include/libport/fwd.hh
+++ b/include/libport/fwd.hh
@@ -11,6 +11,8 @@
 #ifndef LIBPORT_FWD_HH
 # define LIBPORT_FWD_HH
 
+#include <boost/version.hpp>
+
 namespace libport
 {
   // asio.hh;
@@ -63,7 +65,12 @@ namespace boost
 {
   namespace asio
   {
+#if BOOST_VERSION >= 106800
+    class io_context;
+    typedef io_context io_service;
+#else
     class io_service;
+#endif
   }
 }
 

--- a/include/libport/intrusive-ptr.hxx
+++ b/include/libport/intrusive-ptr.hxx
@@ -119,7 +119,7 @@ namespace libport
   intrusive_ptr<T>::cast() const
   {
     U* ptr = dynamic_cast<U*>(pointee_);
-    if (unlikely(!ptr))
+    if (libport_unlikely(!ptr))
       throw std::bad_cast ();
     return ptr;
   }

--- a/include/libport/meta.hh
+++ b/include/libport/meta.hh
@@ -22,8 +22,13 @@ namespace libport
 {
   namespace meta
   {
+#if __cplusplus > 201100
+    using std::remove_const;
+    using std::remove_reference;
+#else
     using std::tr1::remove_const;
     using std::tr1::remove_reference;
+#endif
 
     /// Uniquify T by combining it with a unique id I
     template <typename T, int I>
@@ -126,7 +131,7 @@ namespace libport
     struct Flatten
     {
       typedef typename
-        std::tr1::remove_const< typename std::tr1::remove_reference<T>::type >::type
+        remove_const< typename remove_reference<T>::type >::type
       type;
     };
 

--- a/include/libport/option-parser.hxx
+++ b/include/libport/option-parser.hxx
@@ -22,7 +22,7 @@ namespace libport
   {
     if (!filled_)
     {
-      aver(def);
+      aver(!!def);
       return def.get();
     }
     return boost::lexical_cast<T>(value_);

--- a/include/libport/tr1/type_traits
+++ b/include/libport/tr1/type_traits
@@ -19,12 +19,18 @@
 
 # include <libport/config.h>
 
-# if defined(LIBPORT_HAVE_TR1_TYPE_TRAITS) || (_MSC_VER >= 1700)
+# if defined(LIBPORT_HAVE_TR1_TYPE_TRAITS) || (__cplusplus >= 201100) || (_MSC_VER >= 1700)
 #  include <type_traits>
 #  define BOOST_TR1_TYPE_TRAITS_HPP_INCLUDED
 # else
 #  include <boost/tr1/type_traits.hpp>
 # endif // !LIBPORT_HAVE_TR1_TYPE_TRAITS
+
+#if (__cplusplus >= 201100)
+# define LIBPORT_TRAIT_NAMESPACE std
+#else
+# define LIBPORT_TRAIT_NAMESPACE std::tr1
+#endif
 
 #endif // !LIBPORT_TR1_TYPE_TRAITS
 

--- a/include/libport/traits.hh
+++ b/include/libport/traits.hh
@@ -34,7 +34,7 @@ namespace libport
     template <typename T>
     struct IsPOD
     {
-      static const bool res = std::tr1::is_pod<T>::value;
+      static const bool res = LIBPORT_TRAIT_NAMESPACE::is_pod<T>::value;
     };
 
     /*-----.

--- a/include/sched/exception.hh
+++ b/include/sched/exception.hh
@@ -38,7 +38,7 @@ namespace sched
 /// Define an optional field Name, and accessors.
 #define ADD_FIELD(Type, Name)						\
  public:                                                                \
-   bool Name ## _is_set() const { return Name ## _; };			\
+   bool Name ## _is_set() const { return !!Name ## _; };		\
    const Type& Name ## _get() const { return Name ## _ .get(); };	\
    void Name ## _set(const Type& data) { Name ## _ = data; };		\
  private:								\

--- a/lib/libport/asio-impl.hxx
+++ b/lib/libport/asio-impl.hxx
@@ -18,7 +18,6 @@
 #  pragma GCC system_header
 # endif
 #endif
-
 #include <libport/asio.hh>
 #include <libport/system-warning-push.hh>
 #  include <boost/asio.hpp>
@@ -33,6 +32,12 @@
 #include <libport/semaphore.hh>
 #include <libport/thread.hh>
 #include <libport/unistd.h>
+
+#if BOOST_VERSION >= 106800
+# define LIBPORT_BOOST_NATIVE native_handle
+#else
+# define LIBPORT_BOOST_NATIVE native
+#endif
 
 namespace libport
 {
@@ -228,7 +233,7 @@ namespace libport
     native_handle_type
     AcceptorImpl<Acceptor>::getFD() const
     {
-      return base_->native();
+      return base_->LIBPORT_BOOST_NATIVE();
     }
 
     // FIXME: use the delete_ptr in boost::lambda.
@@ -398,7 +403,7 @@ namespace libport
     native_handle_type
     SocketImpl<Stream>::stealFD()
     {
-      size_t fd = base_->lowest_layer().native();
+      size_t fd = base_->lowest_layer().LIBPORT_BOOST_NATIVE();
       fd = dup(fd);
       // Call close, so shutdown wont be called
       base_->lowest_layer().close();
@@ -411,7 +416,7 @@ namespace libport
     SocketImpl<Stream>::getFD() const
     {
       // We need the C-cast here, because underlying type changes with Stream.
-      return (native_handle_type)base_->lowest_layer().native();
+      return (native_handle_type)base_->lowest_layer().LIBPORT_BOOST_NATIVE();
     }
 
 

--- a/lib/libport/asio.cc
+++ b/lib/libport/asio.cc
@@ -11,7 +11,7 @@
 // This compilation unit must not have any ssl-dependent code.
 // Said code goes in asio-ssl.cc
 #define LIBPORT_NO_SSL
-
+#define BOOST_ASIO_ENABLE_OLD_SERVICES
 #include <libport/asio.hh>
 #include <libport/debug.hh>
 #include <libport/containers.hh>

--- a/lib/libport/option-parser.cc
+++ b/lib/libport/option-parser.cc
@@ -305,7 +305,7 @@ namespace libport
   {
     if (!filled_)
     {
-      aver(def);
+      aver(!!def);
       return def.get();
     }
     return value_;


### PR DESCRIPTION
- boost/tr1 is gone
- `likely` libport macro conflicts with some boost code, rename to libport_likely
- adapt to some asio changes