### PR TITLE
Fix race condition during libport::Socket destruction

### DIFF
--- a/lib/libport/asio.cc
+++ b/lib/libport/asio.cc
@@ -836,7 +836,7 @@ namespace libport
       Destructible::DestructionLock l = b->getDestructionLock();
       if (b->isConnected())
       {
-        GD_FINFO_LOG("boost::asio::io_context::post(connection_reset(%p))", this);
+        GD_FINFO_TRACE("boost::asio::io_context::post(connection_reset(%p))", this);
         get_io_service().post(boost::bind(&connection_reset, boost::ref(*this), getDestructionLock()));
       }
       b->close();

--- a/lib/libport/asio.cc
+++ b/lib/libport/asio.cc
@@ -836,11 +836,8 @@ namespace libport
       Destructible::DestructionLock l = b->getDestructionLock();
       if (b->isConnected())
       {
-        GD_FINFO_TRACE("asyncCall(connection_reset(%p))", this);
-        asyncCall(boost::bind(&connection_reset,
-                              boost::ref(*this), getDestructionLock()),
-                  10,
-                  get_io_service());
+        GD_FINFO_LOG("boost::asio::io_context::post(connection_reset(%p))", this);
+        get_io_service().post(boost::bind(&connection_reset, boost::ref(*this), getDestructionLock()));
       }
       b->close();
       b->destroy();


### PR DESCRIPTION
It solves https://github.com/urbiforge/urbi/issues/9. I believe that intention to call `connection_reset` as an asynchronous call with delay 10us was just call it asynchronously. Thus, it could be just post into boost::asio::io_context, which reduce possibility of race condition with blocking `libport::Socket::~Socket`.