### PR TITLE
Libport asio linking error

### DIFF
--- a/include/libport/asio.hh
+++ b/include/libport/asio.hh
@@ -26,6 +26,7 @@
 # if defined __GNUC__ && defined __APPLE__
 #  pragma GCC visibility push(default)
 # endif
+# define BOOST_ASIO_ENABLE_OLD_SERVICES
 # include <boost/asio.hpp>
 # if defined LIBPORT_ENABLE_SSL && defined LIBPORT_NO_SSL
 #  undef LIBPORT_ENABLE_SSL


### PR DESCRIPTION
libport::asio is compiled with one version of boost interfaces, but when using libport::asio in other projects, then another version of boost interfaces is used. It cause linking errors. Adding `# define BOOST_ASIO_ENABLE_OLD_SERVICES` aling boost interfaces in libport library and its users.