### PR TITLE
MSVC finally delivers strtoll, snprintf and struct timespec

### DIFF
--- a/include/libport/cstdlib
+++ b/include/libport/cstdlib
@@ -200,18 +200,6 @@ extern "C"
 }
 # endif
 
-/*----------.
-| strtoll.  |
-`----------*/
-
-# if defined _MSC_VER
-extern "C"
-{
-  LIBPORT_API
-  long long strtoll(const char* nptr, char** endptr, int base);
-}
-# endif // WIN32
-
 /*-----------.
 | unsetenv.  |
 `-----------*/

--- a/include/libport/ctime
+++ b/include/libport/ctime
@@ -19,18 +19,6 @@
 #  include <libport/windows.hh>
 # endif
 
-/*-----------.
-| timespec.  |
-`-----------*/
-
-# if defined WIN32
-struct timespec
-{
-  time_t tv_sec;
-  long tv_nsec;
-};
-# endif
-
 /*--------------.
 | localtime_r.  |
 `--------------*/

--- a/include/sched/libcoroutine/Common.h
+++ b/include/sched/libcoroutine/Common.h
@@ -29,9 +29,6 @@ These defines are helpful for doing OS specific checks in the code.
 
 #if defined(WIN32) || defined(__WINS__) || defined(__MINGW32__) || defined(_MSC_VER)
 #define inline __inline
-#if defined _MSC_VER
-# define snprintf _snprintf
-#endif
 #define usleep(x) Sleep(((x)+999)/1000)
 
 #define HAS_FIBERS 1

--- a/lib/libport/cstdlib.cc
+++ b/lib/libport/cstdlib.cc
@@ -36,18 +36,6 @@
 #  include <crt_externs.h>
 # endif
 
-#ifdef _MSC_VER
-
-extern "C"
-{
-  long long
-  strtoll(const char* nptr, char** endptr, int base)
-  {
-    return _strtoi64(nptr, endptr, base);
-  }
-}
-#endif
-
 #if defined _MSC_VER || defined __MINGW32__
 
 namespace libport


### PR DESCRIPTION
Visual Studio 2015 (a.k.a. msvc v140) finally delivers missing symbols. I do not know how to write ifdefs, because I don't know if it depends on toolset version or SDK. However, who use old compilers?:)