### PR TITLE
Fix environ name clash when using MSVC

### DIFF
--- a/lib/libport/cstdlib.cc
+++ b/lib/libport/cstdlib.cc
@@ -124,12 +124,12 @@ namespace libport
 # if defined __APPLE__
     res = env_build(*_NSGetEnviron());
 # elif defined _MSC_VER || defined __MINGW32__
-    char* environ = GetEnvironmentStrings();
-    for (char* cp = environ; *cp; cp += strlen(cp) + 1)
+    char* environVar = GetEnvironmentStrings();
+    for (char* cp = environVar; *cp; cp += strlen(cp) + 1)
       env_add(res, cp);
-    FreeEnvironmentStrings(environ);
+    FreeEnvironmentStrings(environVar);
 # else
-     res = env_build(environ);
+     res = env_build(environVar);
 # endif
     return res;
   }

--- a/lib/libport/cstdlib.cc
+++ b/lib/libport/cstdlib.cc
@@ -129,7 +129,7 @@ namespace libport
       env_add(res, cp);
     FreeEnvironmentStrings(environVar);
 # else
-     res = env_build(environVar);
+     res = env_build(environ);
 # endif
     return res;
   }


### PR DESCRIPTION
When compiling with MSVC, then envrion variable collides with something from MSVC toolset.